### PR TITLE
updated to fix issue with Swift PendingIds having the wrong key name

### DIFF
--- a/ReplicatorManager.swift
+++ b/ReplicatorManager.swift
@@ -93,7 +93,7 @@ public class ReplicatorManager {
         if let replicator = getReplicator(replicatorId: replicatorId) {
             do {
                 let documentIds = try replicator.pendingDocumentIds(collection: collection)
-                return ["documentIds": documentIds];
+                return ["documentIDs": documentIds];
             } catch {
                 throw error
             }


### PR DESCRIPTION
Updated Pending DocumentIds in replication to fix issue where the key name wasn't correct and didn't match what was in Android.