### PR TITLE
fix: updated to fix call to get key that isn't used anymore

### DIFF
--- a/CollectionManager.swift
+++ b/CollectionManager.swift
@@ -57,12 +57,6 @@ public class CollectionManager {
     
     // MARK: - Helper Functions
     
-    public func getCollectionKey(_ collectionName: String,
-                                 scopeName: String,
-                                 databaseName: String) -> String {
-        return "\(databaseName).\(scopeName).\(collectionName)"
-    }
-    
     public func getCollection(_ collectionName: String,
                               scopeName: String,
                               databaseName: String) throws -> Collection? {
@@ -71,10 +65,6 @@ public class CollectionManager {
         }
         
         do {
-            let key = getCollectionKey(
-                collectionName,
-                scopeName: scopeName,
-                databaseName: databaseName)
             guard let collection = try database.collection(
                 name: collectionName,
                 scope: scopeName) else {


### PR DESCRIPTION
Updated Collections to remove the key call that wasn't doing anything.  This was a bug when we were margining open collections which caused too many issues.  When the feature was removed, this code was missed.